### PR TITLE
Close Connection Bugfix

### DIFF
--- a/main.go
+++ b/main.go
@@ -182,7 +182,7 @@ func clientHandler(pipe pipe.TrudyPipe, show bool) {
 
 		data.Serialize()
 
-		_, err = pipe.WriteDestination(data.Bytes[:bytesRead])
+		_, err := pipe.WriteDestination(data.Bytes[:bytesRead])
 		if err != nil || readSourceErr == io.EOF {
 			break
 		}
@@ -250,7 +250,7 @@ func serverHandler(pipe pipe.TrudyPipe) {
 
 		data.Serialize()
 
-		_, err = pipe.WriteSource(data.Bytes[:bytesRead])
+		_, err := pipe.WriteSource(data.Bytes[:bytesRead])
 		if err != nil || readDestErr == io.EOF {
 			break
 		}


### PR DESCRIPTION
I did not account for the case where a TLS connection sends a close-notify with buffered data. I would then check if the error was nil (it wasn't. it was EOF) and would not pass along data to the other end of the pipe. This PR fixes that case.
