### PR TITLE
Updated Source/Destination naming convention.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##Trudy
+## Trudy
 
 [![asciicast](https://asciinema.org/a/7zkywm0biuz1wa64az3tmox8v.png)](https://asciinema.org/a/7zkywm0biuz1wa64az3tmox8v)
 
@@ -12,10 +12,10 @@ Trudy was designed for monitoring and modifying proxy-unaware devices that use n
 
 Written by Kelby Ludwig ([@kelbyludwig](https://twitter.com/kelbyludwig))
 
-###Why I Built This
+### Why I Built This
 I have done security research that invovled sitting between a embedded device and a server and modifying some custom binary protocol on the fly. This usually is a slow process that involves sniffing legitimate traffic, and then rebuilding packets programmatically. Trudy enables Burp-like features for generalized TCP traffic.
 
-###Simple Setup
+### Simple Setup
 
 0. Configure a virtual machine (Trudy has been tested on a 64-bit Debian 8 VM) to shove all traffic through Trudy. I personally use a Vagrant VM that sets this up for me. The Vagrant VM is available [here](https://github.com/praetorian-inc/mitm-vm). If you would like to use different `--to-ports` values, you can use Trudy's command line flags to change Trudy's listening ports.
 
@@ -31,7 +31,7 @@ I have done security research that invovled sitting between a embedded device an
 
     `sysctl -w net.ipv4.ip_forward=1`
 
-1. Clone the repo on the virutal machine and build the Trudy binary.
+1. Clone the repo on the virtual machine and build the Trudy binary.
 
     `git clone https://github.com/kelbyludwig/trudy.git`
 

--- a/main.go
+++ b/main.go
@@ -127,14 +127,14 @@ func clientHandler(pipe pipe.TrudyPipe, show bool) {
 	buffer := make([]byte, 65535)
 
 	for {
-		bytesRead, err := pipe.ReadSource(buffer)
+		bytesRead, err := pipe.ReadFromClient(buffer)
 		if err != nil {
 			break
 		}
 		data := module.Data{FromClient: true,
 			Bytes:    buffer[:bytesRead],
-			DestAddr: pipe.DestinationInfo(),
-			SrcAddr:  pipe.SourceInfo()}
+			DestAddr: pipe.ServerInfo(), //XXX(kkl): Fix the dest / src thing here.
+			SrcAddr:  pipe.ClientInfo()} //XXX(kkl): Fix the dest / src thing here.
 
 		data.Deserialize()
 
@@ -182,7 +182,7 @@ func clientHandler(pipe pipe.TrudyPipe, show bool) {
 
 		data.Serialize()
 
-		_, err = pipe.WriteDestination(data.Bytes[:bytesRead])
+		_, err = pipe.WriteToServer(data.Bytes[:bytesRead])
 		if err != nil {
 			break
 		}
@@ -193,14 +193,14 @@ func serverHandler(pipe pipe.TrudyPipe) {
 	buffer := make([]byte, 65535)
 
 	for {
-		bytesRead, err := pipe.ReadDestination(buffer)
+		bytesRead, err := pipe.ReadFromServer(buffer)
 		if err != nil {
 			break
 		}
 		data := module.Data{FromClient: false,
 			Bytes:    buffer[:bytesRead],
-			DestAddr: pipe.SourceInfo(),
-			SrcAddr:  pipe.DestinationInfo()}
+			DestAddr: pipe.ClientInfo(), //XXX(kkl): Fix the dest / src thing here.
+			SrcAddr:  pipe.ServerInfo()} //XXX(kkl): Fix the dest / src thing here.
 
 		data.Deserialize()
 
@@ -248,7 +248,7 @@ func serverHandler(pipe pipe.TrudyPipe) {
 
 		data.Serialize()
 
-		_, err = pipe.WriteSource(data.Bytes[:bytesRead])
+		_, err = pipe.WriteToClient(data.Bytes[:bytesRead])
 		if err != nil {
 			break
 		}

--- a/main.go
+++ b/main.go
@@ -132,9 +132,9 @@ func clientHandler(pipe pipe.TrudyPipe, show bool) {
 			break
 		}
 		data := module.Data{FromClient: true,
-			Bytes:    buffer[:bytesRead],
-			DestAddr: pipe.ServerInfo(), //XXX(kkl): Fix the dest / src thing here.
-			SrcAddr:  pipe.ClientInfo()} //XXX(kkl): Fix the dest / src thing here.
+			Bytes:      buffer[:bytesRead],
+			ServerAddr: pipe.ServerInfo(),
+			ClientAddr: pipe.ClientInfo()}
 
 		data.Deserialize()
 
@@ -177,7 +177,7 @@ func clientHandler(pipe pipe.TrudyPipe, show bool) {
 		}
 
 		if data.DoPrint() {
-			log.Printf("%v -> %v\n%v\n", data.SrcAddr.String(), data.DestAddr.String(), data.PrettyPrint())
+			log.Printf("%v -> %v\n%v\n", data.ClientAddr.String(), data.ServerAddr.String(), data.PrettyPrint())
 		}
 
 		data.Serialize()
@@ -198,9 +198,9 @@ func serverHandler(pipe pipe.TrudyPipe) {
 			break
 		}
 		data := module.Data{FromClient: false,
-			Bytes:    buffer[:bytesRead],
-			DestAddr: pipe.ClientInfo(), //XXX(kkl): Fix the dest / src thing here.
-			SrcAddr:  pipe.ServerInfo()} //XXX(kkl): Fix the dest / src thing here.
+			Bytes:      buffer[:bytesRead],
+			ClientAddr: pipe.ClientInfo(),
+			ServerAddr: pipe.ServerInfo()}
 
 		data.Deserialize()
 
@@ -243,7 +243,7 @@ func serverHandler(pipe pipe.TrudyPipe) {
 		}
 
 		if data.DoPrint() {
-			log.Printf("%v -> %v\n%v\n", data.DestAddr.String(), data.SrcAddr.String(), data.PrettyPrint())
+			log.Printf("%v -> %v\n%v\n", data.ServerAddr.String(), data.ClientAddr.String(), data.PrettyPrint())
 		}
 
 		data.Serialize()

--- a/module/module.go
+++ b/module/module.go
@@ -9,8 +9,8 @@ import (
 type Data struct {
 	FromClient bool     //FromClient is true is the data sent is coming from the client (the device you are proxying)
 	Bytes      []byte   //Bytes is a byte slice that contians the TCP data
-	DestAddr   net.Addr //DestAddr is net.Addr of the server
-	SrcAddr    net.Addr //SrcAddr is the net.Addr of the client (the device you are proxying)
+	ServerAddr net.Addr //DestAddr is net.Addr of the server
+	ClientAddr net.Addr //SrcAddr is the net.Addr of the client (the device you are proxying)
 }
 
 //DoMangle will return true if Data needs to be sent to the Mangle function.

--- a/module/module.go
+++ b/module/module.go
@@ -9,8 +9,8 @@ import (
 type Data struct {
 	FromClient bool     //FromClient is true is the data sent is coming from the client (the device you are proxying)
 	Bytes      []byte   //Bytes is a byte slice that contians the TCP data
-	ServerAddr net.Addr //DestAddr is net.Addr of the server
-	ClientAddr net.Addr //SrcAddr is the net.Addr of the client (the device you are proxying)
+	ServerAddr net.Addr //ServerAddr is net.Addr of the server
+	ClientAddr net.Addr //ClientAddr is the net.Addr of the client (the device you are proxying)
 }
 
 //DoMangle will return true if Data needs to be sent to the Mangle function.
@@ -18,23 +18,26 @@ func (input Data) DoMangle() bool {
 	return true
 }
 
-//Mangle can modify/replace the Bytes values within the Data struct. This can be empty if no
-//programmatic mangling needs to be done.
+//Mangle can modify/replace the Bytes values within the Data struct. This can
+//be empty if no programmatic mangling needs to be done.
 func (input *Data) Mangle() {
 
 }
 
-//Drop will return true if the Data needs to be dropped before going through the pipe.
+//Drop will return true if the Data needs to be dropped before going through
+//the pipe.
 func (input Data) Drop() bool {
 	return false
 }
 
-//PrettyPrint returns the string representation of the data. This string will be the value that is logged to the console.
+//PrettyPrint returns the string representation of the data. This string will
+//be the value that is logged to the console.
 func (input Data) PrettyPrint() string {
 	return hex.Dump(input.Bytes)
 }
 
-//DoPrint will return true if the PrettyPrinted version of the Data struct needs to be logged to the console.
+//DoPrint will return true if the PrettyPrinted version of the Data struct
+//needs to be logged to the console.
 func (input Data) DoPrint() bool {
 	return true
 }
@@ -50,8 +53,8 @@ func (input *Data) Deserialize() {
 
 }
 
-//Serialize should replace the Data struct's Bytes with the serialized form of the bytes.
-//The serialized bytes will be sent over the wire.
+//Serialize should replace the Data struct's Bytes with the serialized form of
+//the bytes. The serialized bytes will be sent over the wire.
 func (input *Data) Serialize() {
 
 }


### PR DESCRIPTION
Source/Destination was too confusing for pipes. This should fix that issue.
