### PR TITLE
Fix CPU spike by only looping with a non-EOF read

### DIFF
--- a/main.go
+++ b/main.go
@@ -135,7 +135,7 @@ func clientHandler(pipe pipe.Pipe, show bool) {
 			break
 		}
 
-		if bytesRead == 0 {
+		if clientReadErr != io.EOF && bytesRead == 0 {
 			continue
 		}
 
@@ -216,7 +216,7 @@ func serverHandler(pipe pipe.Pipe) {
 			break
 		}
 
-		if bytesRead == 0 {
+		if serverReadErr != io.EOF && bytesRead == 0 {
 			continue
 		}
 


### PR DESCRIPTION
General pseudo-code of what's going on in the processing loop.
```go
for {
  // read and err on non-EOF
  n, readErr := read(buf)
  if readErr != io.EOF && readErr != nil {
    break
  }
  
  // if there are no bytes, continue!
  // previously, this would `continue` forever on the condition (0 bytes read && EOF)
  if readErr != io.EOF && n == 0 {
    continue
  }
  
  // process bytes, even if there's an EOF
  process(buf)
  
  // write and clean up potential EOF
  _, writeErr := write(buf)
  if writeErr != nil || readErr == io.EOF {
    break
  }
}
```

Fixes #22.